### PR TITLE
Unique records report

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Usage: `python createDatabase.py`
 This script imports data from an IDC spreadsheet or a directory of spreadsheets
 into the SQLite database.
 
-Usage: `python importIDCData.py FILENAME.csv`
+Usage: `python importIDCData.py 2018q3 FILENAME.csv`
 
-Usage: `python importIDCData.py /DIRECTORY/OF/DATAFILES/`
+Usage: `python importIDCData.py 2018q3 /DIRECTORY/OF/DATAFILES/`
 
 
 ## stratPlanDownload.py

--- a/importIDCData.py
+++ b/importIDCData.py
@@ -74,7 +74,8 @@ def import_file(filename, q, conn):
 
   agencies = []
   rows = []
-  with io.open(filename, 'r') as datafile:
+
+  with io.open(filename, 'r', encoding='utf-8-sig', errors='replace') as datafile:
     headings = None
 
     for line in datafile:
@@ -94,6 +95,7 @@ def import_file(filename, q, conn):
 
       # We only want valid records.
       if row.get('record validity') != 'Valid Facility':
+        print('Skipping: inValid Facility :: '+row.get('data center id'))
         continue
 
       # Overwrite any previous data for this agency for the specified quarter.
@@ -174,6 +176,10 @@ def import_file(filename, q, conn):
           rows = []
 
         conn.commit()
+
+      if not row.get('data center id'):
+        print("Empty 'data center id'")
+        continue
 
       print(row.get('data center id'), year, quarter)
 

--- a/runDCOIReport.py
+++ b/runDCOIReport.py
@@ -327,7 +327,7 @@ data['__meta__'] = {
   'updatedAt': datetime.datetime.now().isoformat()
 }
 
-print( jsonCleanup(json.dumps(data)) )
+print(jsonCleanup(json.dumps(data, indent=2)))
 # TODO: Maybe export a file instead of just printing?
 
 #conn.commit()


### PR DESCRIPTION
Since there is no proper way of managing unique records in `datacenters` table, we create a new `datacenters_uniq` table during export and copy only unique records, also removing invalid outdated records.